### PR TITLE
Fixed

### DIFF
--- a/apps/aavantan-frontend/src/app/backlog/backlog.component.html
+++ b/apps/aavantan-frontend/src/app/backlog/backlog.component.html
@@ -56,43 +56,46 @@
         <!-- sprint duration -->
         <div class="row clearfix m-b-10 m-t-10">
 
-          <div class="col-md-7 p-t-10" *ngIf="(unPublishedSprintData && unPublishedSprintData.id) || sprintDurations">
-            <span class="font-size-14">
-
-              <span class="font-size-18 m-r-30 text-black font-weight-normal"
-                    *ngIf="unPublishedSprintData?.name">{{unPublishedSprintData?.name}}</span>
-
-              <span class="m-r-25 text-gray-light-2 font-size-13"
-                    *ngIf="sprintDurations?.totalEstimationReadable">
-                <span class="font-weight-semibold">{{sprintDurations?.totalEstimationReadable}}</span>
-                <span class="font-weight-light">  Sprint Hours </span>
-              </span>
-
-              <span class="m-r-10 text-gray-light-2 font-size-13">
-                <span class="font-weight-semibold">{{sprintDurations?.totalCapacityReadable}}</span>
-                <span class="m-r-25 font-weight-light"> Sprint Capacity</span>
-              </span>
+          <div class="col-md-8 font-size-14" *ngIf="(unPublishedSprintData && unPublishedSprintData.id) || sprintDurations">
 
 
-              <span class="font-size-13 m-r-25"
-                    [ngClass]="{'text-gray-light-2 font-weight-semibold': sprintDurations?.totalRemainingCapacity>0,
-                    'text-red font-weight-semibold': sprintDurations?.totalRemainingCapacity<0}"
-                    *ngIf="sprintDurations?.totalRemainingCapacityReadable">
-                <span
-                  class="p-l-5">{{sprintDurations?.totalRemainingCapacityReadable}}</span>
-                <span class="font-weight-light"> Remains</span>
-              </span>
+              <div class="font-size-18 m-r-10 text-black font-weight-normal"
+                    *ngIf="unPublishedSprintData?.name">{{unPublishedSprintData?.name}}</div>
 
-              <span class="text-gray-light-2" *ngIf="totalItemsInSprint>0">
-                <span class="text-gray-light-2 font-weight-semibold">{{totalItemsInSprint}}&nbsp;</span>
-                <span class="font-weight-light">{{totalItemsInSprint === 1 ? 'Item' : 'Items'}} in Sprint</span>
-              </span>
 
-            </span>
+              <div [ngClass]="unPublishedSprintData?.name ? '' : 'p-t-10'">
+                <span class="m-r-25 text-gray-light-2 font-size-13"
+                      *ngIf="sprintDurations?.totalEstimationReadable">
+                  <span class="font-weight-semibold">{{sprintDurations?.totalEstimationReadable}}</span>
+                  <span class="font-weight-light">  Sprint Hours </span>
+                </span>
+
+                <span class="m-r-10 text-gray-light-2 font-size-13">
+                  <span class="font-weight-semibold">{{sprintDurations?.totalCapacityReadable}}</span>
+                  <span class="m-r-25 font-weight-light"> Sprint Capacity</span>
+                </span>
+
+
+                <span class="font-size-13 m-r-25"
+                      [ngClass]="{'text-gray-light-2 font-weight-semibold': sprintDurations?.totalRemainingCapacity>0,
+                      'text-red font-weight-semibold': sprintDurations?.totalRemainingCapacity<0}"
+                      *ngIf="sprintDurations?.totalRemainingCapacityReadable">
+                  <span
+                    class="p-l-5">{{sprintDurations?.totalRemainingCapacityReadable}}</span>
+                  <span class="font-weight-light"> Remains</span>
+                </span>
+
+                <span class="text-gray-light-2" *ngIf="totalItemsInSprint>0">
+                  <span class="text-gray-light-2 font-weight-semibold">{{totalItemsInSprint}}&nbsp;</span>
+                  <span class="font-weight-light">{{totalItemsInSprint === 1 ? 'Item' : 'Items'}} in Sprint</span>
+                </span>
+              </div>
+
+
           </div>
 
 
-          <div class="col-md-5 text-right">
+          <div class="col-md-4 text-right">
             <span *ngIf="(unPublishedSprintData?.id)">
               <button class="m-l-10" [disabled]="!draftTaskList?.length" [nzLoading]="publishSprintInProcess"
                       nzType="primary" nzSize="small" nz-button (click)="publishSprint()">Publish Sprint</button>

--- a/apps/aavantan-frontend/src/app/dashboard/home/home.component.html
+++ b/apps/aavantan-frontend/src/app/dashboard/home/home.component.html
@@ -273,12 +273,12 @@
         <tr>
 
           <th>Name</th>
-          <th>Capacity</th>
-          <th>Assigned Time</th>
-          <th>Worked</th>
-          <th>Remaining Work</th>
-          <th>Remaining Capacity</th>
-          <th>Productivity</th>
+          <th class="text-right">Capacity</th>
+          <th class="text-right">Assigned Time</th>
+          <th class="text-right">Worked</th>
+          <th class="text-right">Remaining Work</th>
+          <th class="text-right">Remaining Capacity</th>
+          <th class="text-right">Productivity</th>
 
         </tr>
 
@@ -288,12 +288,12 @@
 
         <tr *ngFor="let item of sprintReport.reportMembers">
           <td data-label="Name">{{ item.user.firstName }} {{ item.user.lastName }}</td>
-          <td data-label="Capacity">{{ item.workingCapacityReadable }}</td>
-          <td data-label="Assigned Time">{{ item.totalAssignedTimeReadable }}</td>
-          <td data-label="Worked">{{ item.totalLoggedTimeReadable }}</td>
-          <td data-label="Remaining Work">{{ item.totalRemainingTimeReadable }}</td>
-          <td data-label="Remaining Capacity">{{ item.totalRemainingWorkingCapacityReadable }}</td>
-          <td data-label="Productivity">{{ item.sprintProductivity }} %</td>
+          <td class="text-right" data-label="Capacity">{{ item.workingCapacityReadable }}</td>
+          <td class="text-right" data-label="Assigned Time">{{ item.totalAssignedTimeReadable }}</td>
+          <td class="text-right" data-label="Worked">{{ item.totalLoggedTimeReadable }}</td>
+          <td class="text-right" data-label="Remaining Work">{{ item.totalRemainingTimeReadable }}</td>
+          <td class="text-right" data-label="Remaining Capacity">{{ item.totalRemainingWorkingCapacityReadable }}</td>
+          <td class="text-right" data-label="Productivity">{{ item.sprintProductivity }} %</td>
         </tr>
 
         </tbody>
@@ -304,12 +304,12 @@
         <thead>
         <tr>
           <th>Total</th>
-          <th>{{ sprintReport.reportMembersTotalWorkingCapacityReadable }}</th>
-          <th>{{ sprintReport.reportMembersTotalAssignedTimeReadable }}</th>
-          <th>{{ sprintReport.reportMembersTotalLoggedTimeReadable }}</th>
-          <th>{{ sprintReport.reportMembersTotalRemainingTimeReadable }}</th>
-          <th>{{ sprintReport.reportMembersTotalRemainingWorkingCapacityReadable }}</th>
-          <th>{{ sprintReport.reportMembersTotalSprintProductivity }} %</th>
+          <th class="text-right">{{ sprintReport.reportMembersTotalWorkingCapacityReadable }}</th>
+          <th class="text-right">{{ sprintReport.reportMembersTotalAssignedTimeReadable }}</th>
+          <th class="text-right">{{ sprintReport.reportMembersTotalLoggedTimeReadable }}</th>
+          <th class="text-right">{{ sprintReport.reportMembersTotalRemainingTimeReadable }}</th>
+          <th class="text-right">{{ sprintReport.reportMembersTotalRemainingWorkingCapacityReadable }}</th>
+          <th class="text-right">{{ sprintReport.reportMembersTotalSprintProductivity }} %</th>
         </tr>
         </thead>
       </table>


### PR DESCRIPTION
1. Home page > Sprint Members section table column alignment

2. Backlog > If sprint name is large then UI is breaking into 2 lines